### PR TITLE
Update login_fedid.md

### DIFF
--- a/login_fedid.md
+++ b/login_fedid.md
@@ -94,7 +94,7 @@ The required API key is the {{site.data.keyword.Bluemix_notm}} API key that's us
     * Call the API key with the key file:
 
       ```
-      ibmcloud login --apikey @key_file_name
+      ibmcloud login --apikey '@key_file_name'
 
       ```
 


### PR DESCRIPTION
For Windows 10 pro, change:
ibmcloud login --apikey @key_file_name
to:
ibmcloud login --apikey '@key_file_name'

on Windows 10 pro it won't work without apostrophes with this error:

PS C:\_work\cloud> ibmcloud login --apikey @api_key
Incorrect Usage.

NAME:
  login - Log user in

USAGE:
   C:\Program Files\IBM\Cloud\bin\ibmcloud.exe login [-a API_ENDPOINT] [--sso] [-u USERNAME] [-p PASSWORD] [--apikey KEY | @KEY_FILE] [--no-iam] [-c ACCOUNT_ID | --no-account] [-g RESOURCE_GROUP] [-r REGION | --no-region] [-o ORG] [-s SPACE]


or with this error if the file contains dot and an extension:

PS C:\_work\cloud> ibmcloud login --apikey @api_key.txt
At line:1 char:25
+ ibmcloud login --apikey @api_key.txt
+                         ~~~~~~~~
The splatting operator '@' cannot be used to reference variables in an expression. '@api_key' can be used only as an argument to a command. To reference variables in an
expression use '$api_key'.
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : SplattingNotPermitted

I did the change, but this should be checked on Linux
(or 2 commands should be provided - one for linux and one for windows)